### PR TITLE
fix: use upload buffer for data URL generation

### DIFF
--- a/src/payload/hooks/add-data-url.ts
+++ b/src/payload/hooks/add-data-url.ts
@@ -1,31 +1,24 @@
 import type { CollectionAfterChangeHook } from 'payload';
-import sharp from 'sharp';
 
 import type { PayloadMediaCollection } from '@/payload/payload-types';
+import { createDataUrl } from '@/payload/utils/create-data-url';
 
 export const addDataUrl: CollectionAfterChangeHook<PayloadMediaCollection> = async ({
   context,
   doc,
   req,
 }) => {
-  if (!doc.url || context?.ignoreAfterChange) {
+  if (!req.file?.data || context?.ignoreAddDataUrl) {
     return doc;
   }
 
-  const image = await fetch(doc.url);
-  const imageBuffer = await image.arrayBuffer();
-  const sharpBuffer = await sharp(imageBuffer).resize(50).toBuffer();
-  const dataUrl = `data:${doc.mimeType};base64,${sharpBuffer.toString('base64')}`;
+  const dataUrl = await createDataUrl(req.file.data, doc.mimeType);
 
   return req.payload.update({
     collection: 'media',
     id: doc.id,
-    data: {
-      dataUrl,
-    },
-    context: {
-      ignoreAfterChange: true,
-    },
-    req,
+    data: { dataUrl },
+    context: { ignoreAddDataUrl: true },
+    req: { transactionID: req.transactionID, user: req.user },
   });
 };

--- a/src/payload/utils/create-data-url.ts
+++ b/src/payload/utils/create-data-url.ts
@@ -1,0 +1,14 @@
+import sharp from 'sharp';
+
+export async function createDataUrl(
+  data: Buffer,
+  mimeType?: string | null,
+): Promise<string | null> {
+  try {
+    const sharpBuffer = await sharp(data).resize(50).toBuffer();
+
+    return `data:${mimeType || 'image/png'};base64,${sharpBuffer.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Use `req.file.data` (in-memory buffer) instead of fetching `doc.url` for blur placeholder generation
- Avoids race condition where URL isn't available yet (cloud storage hook hasn't run)
- Extracts `createDataUrl` utility with error handling
- Passes minimal `req` to nested update to prevent re-triggering storage hooks

## Test plan

- [ ] Upload an image via Payload admin and confirm `dataUrl` field is populated
- [ ] Confirm blur placeholder renders on frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)